### PR TITLE
DB에서 교사계정 학번 저장시 오류 해결

### DIFF
--- a/src/main/kotlin/site/iplease/accountserver/global/common/entity/Account.kt
+++ b/src/main/kotlin/site/iplease/accountserver/global/common/entity/Account.kt
@@ -14,7 +14,7 @@ data class Account(
     val name: String,
     val email: String,
     val encodedPassword: String,
-    val studentNumber: Int = 1101,
+    val studentNumber: Int = -1,
     val department: DepartmentType = DepartmentType.SOFTWARE_DEVELOP,
     val profileImageUrl: String
 )


### PR DESCRIPTION
현재 Account에 대한 상속매핑은 단일 테이블(Single Table) 전략으로 구현되어있습니다.
따라서, DB에서 교사계정의 학번을 저장할 경우, AccountEntity의 기본값인 `1101`로 저장하게 됩니다. 
이는 이후, 학생계정의 학번과 겹치거나 잘못된 정보를 전달할 위험이 있으므로, 기본값을 `-1`로 수정하였습니다.